### PR TITLE
Assorted Base32 cleanup

### DIFF
--- a/Base32/Alphabet.swift
+++ b/Base32/Alphabet.swift
@@ -6,6 +6,26 @@
 //  Copyright (c) 2015 Matt Rubin. All rights reserved.
 //
 
+// Each 5-bit group is used as an index into an array of 32 printable
+// characters.  The character referenced by the index is placed in the
+// output string.  These characters, identified in Table 3, below, are
+// selected from US-ASCII digits and uppercase letters.
+//
+//                   Table 3: The Base 32 Alphabet
+//
+//   Value Encoding  Value Encoding  Value Encoding  Value Encoding
+//       0 A             9 J            18 S            27 3
+//       1 B            10 K            19 T            28 4
+//       2 C            11 L            20 U            29 5
+//       3 D            12 M            21 V            30 6
+//       4 E            13 N            22 W            31 7
+//       5 F            14 O            23 X
+//       6 G            15 P            24 Y         (pad) =
+//       7 H            16 Q            25 Z
+//       8 I            17 R            26 2
+
+internal let pad: Character = "="
+
 public func characterForValue(value: UInt8) -> Character? {
     switch value {
     case  0: return "A"

--- a/Base32/Alphabet.swift
+++ b/Base32/Alphabet.swift
@@ -6,6 +6,16 @@
 //  Copyright (c) 2015 Matt Rubin. All rights reserved.
 //
 
+private func characterOrPaddingForValue(value: Quintet?) -> Character? {
+    if let value = value {
+        // If the quintet has a value, return the corresponding character (if one exists)
+        return characterForValue(value)
+    } else {
+        // If the quintet has no value, return the padding character
+        return "="
+    }
+}
+
 // Each 5-bit group is used as an index into an array of 32 printable
 // characters.  The character referenced by the index is placed in the
 // output string.  These characters, identified in Table 3, below, are
@@ -23,8 +33,6 @@
 //       6 G            15 P            24 Y         (pad) =
 //       7 H            16 Q            25 Z
 //       8 I            17 R            26 2
-
-internal let pad: Character = "="
 
 public func characterForValue(value: UInt8) -> Character? {
     switch value {

--- a/Base32/Alphabet.swift
+++ b/Base32/Alphabet.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Matt Rubin. All rights reserved.
 //
 
-private func characterOrPaddingForValue(value: Quintet?) -> Character? {
+func characterOrPaddingForValue(value: Quintet?) -> Character? {
     if let value = value {
         // If the quintet has a value, return the corresponding character (if one exists)
         return characterForValue(value)

--- a/Base32/Base32.h
+++ b/Base32/Base32.h
@@ -5,15 +5,3 @@
 //  Created by Matt Rubin on 3/28/15.
 //  Copyright (c) 2015 Matt Rubin. All rights reserved.
 //
-
-@import Foundation;
-
-//! Project version number for Base32.
-FOUNDATION_EXPORT double Base32VersionNumber;
-
-//! Project version string for Base32.
-FOUNDATION_EXPORT const unsigned char Base32VersionString[];
-
-// In this header, you should import all the public headers of your framework using statements like #import <Base32/PublicHeader.h>
-
-

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -7,6 +7,7 @@
 //
 
 private let quantumSize = 5
+private let pad: Character = "="
 
 public func encode(bytes: ArraySlice<UInt8>) -> String? {
     if let s = encodeQuantum(bytes) {
@@ -46,7 +47,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
             c0 = characterForValue(q.0),
             c1 = characterForValue(q.1)
         {
-            return String([c0, c1, "=", "=", "=", "=", "=", "="])
+            return String([c0, c1, pad, pad, pad, pad, pad, pad])
         }
     case 2:
         // The final quantum of encoding input is exactly 16 bits; here, the
@@ -59,7 +60,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
             c2 = characterForValue(q.2),
             c3 = characterForValue(q.3)
         {
-            return String([c0, c1, c2, c3, "=", "=", "=", "="])
+            return String([c0, c1, c2, c3, pad, pad, pad, pad])
         }
     case 3:
         // The final quantum of encoding input is exactly 24 bits; here, the
@@ -73,7 +74,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
             c3 = characterForValue(q.3),
             c4 = characterForValue(q.4)
         {
-            return String([c0, c1, c2, c3, c4, "=", "=", "="])
+            return String([c0, c1, c2, c3, c4, pad, pad, pad])
         }
     case 4:
         // The final quantum of encoding input is exactly 32 bits; here, the
@@ -89,7 +90,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
             c5 = characterForValue(q.5),
             c6 = characterForValue(q.6)
         {
-            return String([c0, c1, c2, c3, c4, c5, c6, "="])
+            return String([c0, c1, c2, c3, c4, c5, c6, pad])
         }
     default:
         // The final quantum of encoding input is an integral multiple of 40

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -112,7 +112,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
 private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8)
     -> (Character, Character, Character, Character, Character, Character, Character, Character)?
 {
-    let q = quintets(b0, b1, b2, b3, b4)
+    let q = quintets(b0, b1, b2, b3, b4: b4)
     if let
         c0 = characterForValue(q.0),
         c1 = characterForValue(q.1),
@@ -121,7 +121,7 @@ private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: 
         c4 = characterForValue(q.4),
         c5 = characterForValue(q.5),
         c6 = characterForValue(q.6),
-        c7 = characterForValue(q.7)
+        c7 = q.7.flatMap(characterForValue)
     {
         return (c0, c1, c2, c3, c4, c5, c6, c7)
     } else {

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -46,9 +46,7 @@ private func encodeQuantum(bytes: ArraySlice<Byte>) -> String? {
     }
 }
 
-
-private func stringForBytes(b0: Byte, b1: Byte?, b2: Byte?, b3: Byte?, b4: Byte?)
-    -> String?
+private func stringForBytes(b0: Byte, b1: Byte?, b2: Byte?, b3: Byte?, b4: Byte?) -> String?
 {
     let q = quintetsFromBytes(b0, b1, b2, b3, b4)
     if let

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -30,41 +30,18 @@ private func encode(bytes: ArraySlice<UInt8>) -> String? {
 }
 
 private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
-    // Special processing is performed if fewer than 40 bits are available
-    // at the end of the data being encoded.  A full encoding quantum is
-    // always completed at the end of a body.  When fewer than 40 input bits
-    // are available in an input group, bits with value zero are added (on
-    // the right) to form an integral number of 5-bit groups.  Padding at
-    // the end of the data is performed using the "=" character.  Since all
-    // base 32 input is an integral number of octets, only the following
-    // cases can arise:
     switch bytes.count {
     case 0:
         return ""
     case 1:
-        // The final quantum of encoding input is exactly 8 bits; here, the
-        // final unit of encoded output will be two characters followed by
-        // six "=" padding characters.
         return stringForBytes(bytes[0], nil, nil, nil, nil)
     case 2:
-        // The final quantum of encoding input is exactly 16 bits; here, the
-        // final unit of encoded output will be four characters followed by
-        // four "=" padding characters.
         return stringForBytes(bytes[0], bytes[1], nil, nil, nil)
     case 3:
-        // The final quantum of encoding input is exactly 24 bits; here, the
-        // final unit of encoded output will be five characters followed by
-        // three "=" padding characters.
         return stringForBytes(bytes[0], bytes[1], bytes[2], nil, nil)
     case 4:
-        // The final quantum of encoding input is exactly 32 bits; here, the
-        // final unit of encoded output will be seven characters followed by
-        // one "=" padding character.
         return stringForBytes(bytes[0], bytes[1], bytes[2], bytes[3], nil)
     default:
-        // The final quantum of encoding input is an integral multiple of 40
-        // bits; here, the final unit of encoded output will be an integral
-        // multiple of 8 characters with no "=" padding.
         return stringForBytes(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4])
     }
 }

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -83,17 +83,8 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
         // The final quantum of encoding input is exactly 32 bits; here, the
         // final unit of encoded output will be seven characters followed by
         // one "=" padding character.
-        let q = quintets(bytes[0], bytes[1], bytes[2], bytes[3])
-        if let
-            c0 = characterForValue(q.0),
-            c1 = characterForValue(q.1),
-            c2 = characterForValue(q.2),
-            c3 = characterForValue(q.3),
-            c4 = characterForValue(q.4),
-            c5 = characterForValue(q.5),
-            c6 = characterForValue(q.6)
-        {
-            return String([c0, c1, c2, c3, c4, c5, c6, pad])
+        if let c = charactersForBytes(bytes[0], bytes[1], bytes[2], bytes[3], nil) {
+            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
         }
     default:
         // The final quantum of encoding input is an integral multiple of 40
@@ -109,10 +100,10 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
 }
 
 
-private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8)
+private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8?)
     -> (Character, Character, Character, Character, Character, Character, Character, Character)?
 {
-    let q = quintets(b0, b1, b2, b3, b4: b4)
+    let q = quintets(b0, b1, b2, b3, b4)
     if let
         c0 = characterForValue(q.0),
         c1 = characterForValue(q.1),
@@ -121,7 +112,7 @@ private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: 
         c4 = characterForValue(q.4),
         c5 = characterForValue(q.5),
         c6 = characterForValue(q.6),
-        c7 = q.7.flatMap(characterForValue)
+        c7 = characterOrPaddingForValue(q.7)
     {
         return (c0, c1, c2, c3, c4, c5, c6, c7)
     } else {
@@ -129,3 +120,10 @@ private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: 
     }
 }
 
+private func characterOrPaddingForValue(value: UInt8?) -> Character? {
+    if let value = value {
+        return characterForValue(value)
+    } else {
+        return pad
+    }
+}

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -99,21 +99,33 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
         // The final quantum of encoding input is an integral multiple of 40
         // bits; here, the final unit of encoded output will be an integral
         // multiple of 8 characters with no "=" padding.
-        let q = quintets(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4])
-        if let
-            c0 = characterForValue(q.0),
-            c1 = characterForValue(q.1),
-            c2 = characterForValue(q.2),
-            c3 = characterForValue(q.3),
-            c4 = characterForValue(q.4),
-            c5 = characterForValue(q.5),
-            c6 = characterForValue(q.6),
-            c7 = characterForValue(q.7)
-        {
-            return String([c0, c1, c2, c3, c4, c5, c6, c7])
+        if let c = charactersForBytes(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4]) {
+            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
         }
     }
 
     // Something failed
     return nil
 }
+
+
+private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8)
+    -> (Character, Character, Character, Character, Character, Character, Character, Character)?
+{
+    let q = quintets(b0, b1, b2, b3, b4)
+    if let
+        c0 = characterForValue(q.0),
+        c1 = characterForValue(q.1),
+        c2 = characterForValue(q.2),
+        c3 = characterForValue(q.3),
+        c4 = characterForValue(q.4),
+        c5 = characterForValue(q.5),
+        c6 = characterForValue(q.6),
+        c7 = characterForValue(q.7)
+    {
+        return (c0, c1, c2, c3, c4, c5, c6, c7)
+    } else {
+        return nil
+    }
+}
+

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -7,7 +7,6 @@
 //
 
 private let quantumSize = 5
-private let pad: Character = "="
 
 public func encode(bytes: ArraySlice<UInt8>) -> String? {
     if let s = encodeQuantum(bytes) {

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -64,11 +64,3 @@ private func stringForBytes(b0: Byte, b1: Byte?, b2: Byte?, b3: Byte?, b4: Byte?
         return nil
     }
 }
-
-private func characterOrPaddingForValue(value: Quintet?) -> Character? {
-    if let value = value {
-        return characterForValue(value)
-    } else {
-        return pad
-    }
-}

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -8,7 +8,11 @@
 
 private let quantumSize = 5
 
-public func encode(bytes: ArraySlice<UInt8>) -> String? {
+public func base32<S: SequenceType where S.Generator.Element == UInt8>(bytes: S) -> String? {
+    return encode(ArraySlice(bytes))
+}
+
+private func encode(bytes: ArraySlice<UInt8>) -> String? {
     if let s = encodeQuantum(bytes) {
         if bytes.count <= quantumSize {
             return s

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -12,7 +12,7 @@ public func base32<S: SequenceType where S.Generator.Element == UInt8>(bytes: S)
     return encode(ArraySlice(bytes))
 }
 
-private func encode(bytes: ArraySlice<UInt8>) -> String? {
+private func encode(bytes: ArraySlice<Byte>) -> String? {
     if let s = encodeQuantum(bytes) {
         if bytes.count <= quantumSize {
             return s
@@ -29,7 +29,7 @@ private func encode(bytes: ArraySlice<UInt8>) -> String? {
     return nil
 }
 
-private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
+private func encodeQuantum(bytes: ArraySlice<Byte>) -> String? {
     switch bytes.count {
     case 0:
         return ""
@@ -47,7 +47,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
 }
 
 
-private func stringForBytes(b0: UInt8, b1: UInt8?, b2: UInt8?, b3: UInt8?, b4: UInt8?)
+private func stringForBytes(b0: Byte, b1: Byte?, b2: Byte?, b3: Byte?, b4: Byte?)
     -> String?
 {
     let q = quintetsFromBytes(b0, b1, b2, b3, b4)
@@ -67,7 +67,7 @@ private func stringForBytes(b0: UInt8, b1: UInt8?, b2: UInt8?, b3: UInt8?, b4: U
     }
 }
 
-private func characterOrPaddingForValue(value: UInt8?) -> Character? {
+private func characterOrPaddingForValue(value: Quintet?) -> Character? {
     if let value = value {
         return characterForValue(value)
     } else {

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -45,12 +45,8 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
         // The final quantum of encoding input is exactly 8 bits; here, the
         // final unit of encoded output will be two characters followed by
         // six "=" padding characters.
-        let q = quintets(bytes[0])
-        if let
-            c0 = characterForValue(q.0),
-            c1 = characterForValue(q.1)
-        {
-            return String([c0, c1, pad, pad, pad, pad, pad, pad])
+        if let c = charactersForBytes(bytes[0], nil, nil, nil, nil) {
+            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
         }
     case 2:
         // The final quantum of encoding input is exactly 16 bits; here, the
@@ -87,15 +83,15 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
 }
 
 
-private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8?, b3: UInt8?, b4: UInt8?)
+private func charactersForBytes(b0: UInt8, b1: UInt8?, b2: UInt8?, b3: UInt8?, b4: UInt8?)
     -> (Character, Character, Character, Character, Character, Character, Character, Character)?
 {
     let q = quintets(b0, b1, b2, b3, b4)
     if let
         c0 = characterForValue(q.0),
         c1 = characterForValue(q.1),
-        c2 = characterForValue(q.2),
-        c3 = characterForValue(q.3),
+        c2 = characterOrPaddingForValue(q.2),
+        c3 = characterOrPaddingForValue(q.3),
         c4 = characterOrPaddingForValue(q.4),
         c5 = characterOrPaddingForValue(q.5),
         c6 = characterOrPaddingForValue(q.6),

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -26,10 +26,21 @@ public func encode(bytes: ArraySlice<UInt8>) -> String? {
 }
 
 private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
+    // Special processing is performed if fewer than 40 bits are available
+    // at the end of the data being encoded.  A full encoding quantum is
+    // always completed at the end of a body.  When fewer than 40 input bits
+    // are available in an input group, bits with value zero are added (on
+    // the right) to form an integral number of 5-bit groups.  Padding at
+    // the end of the data is performed using the "=" character.  Since all
+    // base 32 input is an integral number of octets, only the following
+    // cases can arise:
     switch bytes.count {
     case 0:
         return ""
     case 1:
+        // The final quantum of encoding input is exactly 8 bits; here, the
+        // final unit of encoded output will be two characters followed by
+        // six "=" padding characters.
         let q = quintets(bytes[0])
         if let
             c0 = characterForValue(q.0),
@@ -38,6 +49,9 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
             return String([c0, c1, "=", "=", "=", "=", "=", "="])
         }
     case 2:
+        // The final quantum of encoding input is exactly 16 bits; here, the
+        // final unit of encoded output will be four characters followed by
+        // four "=" padding characters.
         let q = quintets(bytes[0], bytes[1])
         if let
             c0 = characterForValue(q.0),
@@ -48,6 +62,9 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
             return String([c0, c1, c2, c3, "=", "=", "=", "="])
         }
     case 3:
+        // The final quantum of encoding input is exactly 24 bits; here, the
+        // final unit of encoded output will be five characters followed by
+        // three "=" padding characters.
         let q = quintets(bytes[0], bytes[1], bytes[2])
         if let
             c0 = characterForValue(q.0),
@@ -59,6 +76,9 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
             return String([c0, c1, c2, c3, c4, "=", "=", "="])
         }
     case 4:
+        // The final quantum of encoding input is exactly 32 bits; here, the
+        // final unit of encoded output will be seven characters followed by
+        // one "=" padding character.
         let q = quintets(bytes[0], bytes[1], bytes[2], bytes[3])
         if let
             c0 = characterForValue(q.0),
@@ -72,6 +92,9 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
             return String([c0, c1, c2, c3, c4, c5, c6, "="])
         }
     default:
+        // The final quantum of encoding input is an integral multiple of 40
+        // bits; here, the final unit of encoded output will be an integral
+        // multiple of 8 characters with no "=" padding.
         let q = quintets(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4])
         if let
             c0 = characterForValue(q.0),
@@ -86,6 +109,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
             return String([c0, c1, c2, c3, c4, c5, c6, c7])
         }
     }
+
     // Something failed
     return nil
 }

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -50,7 +50,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
 private func stringForBytes(b0: UInt8, b1: UInt8?, b2: UInt8?, b3: UInt8?, b4: UInt8?)
     -> String?
 {
-    let q = quintets(b0, b1, b2, b3, b4)
+    let q = quintetsFromBytes(b0, b1, b2, b3, b4)
     if let
         c0 = characterForValue(q.0),
         c1 = characterForValue(q.1),

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -31,113 +31,61 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
         return ""
     case 1:
         let q = quintets(bytes[0])
-        if let c = charactersForQuintets(q) {
-            return String([c.0, c.1, "=", "=", "=", "=", "=", "="])
+        if let
+            c0 = characterForValue(q.0),
+            c1 = characterForValue(q.1)
+        {
+            return String([c0, c1, "=", "=", "=", "=", "=", "="])
         }
     case 2:
         let q = quintets(bytes[0], bytes[1])
-        if let c = charactersForQuintets(q) {
-            return String([c.0, c.1, c.2, c.3, "=", "=", "=", "="])
+        if let
+            c0 = characterForValue(q.0),
+            c1 = characterForValue(q.1),
+            c2 = characterForValue(q.2),
+            c3 = characterForValue(q.3)
+        {
+            return String([c0, c1, c2, c3, "=", "=", "=", "="])
         }
     case 3:
         let q = quintets(bytes[0], bytes[1], bytes[2])
-        if let c = charactersForQuintets(q) {
-            return String([c.0, c.1, c.2, c.3, c.4, "=", "=", "="])
+        if let
+            c0 = characterForValue(q.0),
+            c1 = characterForValue(q.1),
+            c2 = characterForValue(q.2),
+            c3 = characterForValue(q.3),
+            c4 = characterForValue(q.4)
+        {
+            return String([c0, c1, c2, c3, c4, "=", "=", "="])
         }
     case 4:
         let q = quintets(bytes[0], bytes[1], bytes[2], bytes[3])
-        if let c = charactersForQuintets(q) {
-            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, "="])
+        if let
+            c0 = characterForValue(q.0),
+            c1 = characterForValue(q.1),
+            c2 = characterForValue(q.2),
+            c3 = characterForValue(q.3),
+            c4 = characterForValue(q.4),
+            c5 = characterForValue(q.5),
+            c6 = characterForValue(q.6)
+        {
+            return String([c0, c1, c2, c3, c4, c5, c6, "="])
         }
     default:
         let q = quintets(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4])
-        if let c = charactersForQuintets(q) {
-            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
+        if let
+            c0 = characterForValue(q.0),
+            c1 = characterForValue(q.1),
+            c2 = characterForValue(q.2),
+            c3 = characterForValue(q.3),
+            c4 = characterForValue(q.4),
+            c5 = characterForValue(q.5),
+            c6 = characterForValue(q.6),
+            c7 = characterForValue(q.7)
+        {
+            return String([c0, c1, c2, c3, c4, c5, c6, c7])
         }
     }
     // Something failed
     return nil
-}
-
-
-// MARK: Quintets -> Characters
-
-private func charactersForQuintets(q0: UInt8, q1: UInt8) -> (Character, Character)?
-{
-    if let
-        c0 = characterForValue(q0),
-        c1 = characterForValue(q1)
-    {
-        return (c0, c1)
-    } else {
-        return nil
-    }
-}
-
-private func charactersForQuintets(q0: UInt8, q1: UInt8, q2: UInt8, q3: UInt8)
-    -> (Character, Character, Character, Character)?
-{
-    if let
-        c0 = characterForValue(q0),
-        c1 = characterForValue(q1),
-        c2 = characterForValue(q2),
-        c3 = characterForValue(q3)
-    {
-        return (c0, c1, c2, c3)
-    } else {
-        return nil
-    }
-}
-
-private func charactersForQuintets(q0: UInt8, q1: UInt8, q2: UInt8, q3: UInt8, q4: UInt8)
-    -> (Character, Character, Character, Character, Character)?
-{
-    if let
-        c0 = characterForValue(q0),
-        c1 = characterForValue(q1),
-        c2 = characterForValue(q2),
-        c3 = characterForValue(q3),
-        c4 = characterForValue(q4)
-    {
-        return (c0, c1, c2, c3, c4)
-    } else {
-        return nil
-    }
-}
-
-private func charactersForQuintets(q0: UInt8, q1: UInt8, q2: UInt8, q3: UInt8, q4: UInt8, q5: UInt8, q6: UInt8)
-    -> (Character, Character, Character, Character, Character, Character, Character)?
-{
-    if let
-        c0 = characterForValue(q0),
-        c1 = characterForValue(q1),
-        c2 = characterForValue(q2),
-        c3 = characterForValue(q3),
-        c4 = characterForValue(q4),
-        c5 = characterForValue(q5),
-        c6 = characterForValue(q6)
-    {
-        return (c0, c1, c2, c3, c4, c5, c6)
-    } else {
-        return nil
-    }
-}
-
-private func charactersForQuintets(q0: UInt8, q1: UInt8, q2: UInt8, q3: UInt8, q4: UInt8, q5: UInt8, q6: UInt8, q7: UInt8)
-    -> (Character, Character, Character, Character, Character, Character, Character, Character)?
-{
-    if let
-        c0 = characterForValue(q0),
-        c1 = characterForValue(q1),
-        c2 = characterForValue(q2),
-        c3 = characterForValue(q3),
-        c4 = characterForValue(q4),
-        c5 = characterForValue(q5),
-        c6 = characterForValue(q6),
-        c7 = characterForValue(q7)
-    {
-        return (c0, c1, c2, c3, c4, c5, c6, c7)
-    } else {
-        return nil
-    }
 }

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -45,46 +45,33 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
         // The final quantum of encoding input is exactly 8 bits; here, the
         // final unit of encoded output will be two characters followed by
         // six "=" padding characters.
-        if let c = charactersForBytes(bytes[0], nil, nil, nil, nil) {
-            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
-        }
+        return stringForBytes(bytes[0], nil, nil, nil, nil)
     case 2:
         // The final quantum of encoding input is exactly 16 bits; here, the
         // final unit of encoded output will be four characters followed by
         // four "=" padding characters.
-        if let c = charactersForBytes(bytes[0], bytes[1], nil, nil, nil) {
-            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
-        }
+        return stringForBytes(bytes[0], bytes[1], nil, nil, nil)
     case 3:
         // The final quantum of encoding input is exactly 24 bits; here, the
         // final unit of encoded output will be five characters followed by
         // three "=" padding characters.
-        if let c = charactersForBytes(bytes[0], bytes[1], bytes[2], nil, nil) {
-            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
-        }
+        return stringForBytes(bytes[0], bytes[1], bytes[2], nil, nil)
     case 4:
         // The final quantum of encoding input is exactly 32 bits; here, the
         // final unit of encoded output will be seven characters followed by
         // one "=" padding character.
-        if let c = charactersForBytes(bytes[0], bytes[1], bytes[2], bytes[3], nil) {
-            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
-        }
+        return stringForBytes(bytes[0], bytes[1], bytes[2], bytes[3], nil)
     default:
         // The final quantum of encoding input is an integral multiple of 40
         // bits; here, the final unit of encoded output will be an integral
         // multiple of 8 characters with no "=" padding.
-        if let c = charactersForBytes(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4]) {
-            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
-        }
+        return stringForBytes(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4])
     }
-
-    // Something failed
-    return nil
 }
 
 
-private func charactersForBytes(b0: UInt8, b1: UInt8?, b2: UInt8?, b3: UInt8?, b4: UInt8?)
-    -> (Character, Character, Character, Character, Character, Character, Character, Character)?
+private func stringForBytes(b0: UInt8, b1: UInt8?, b2: UInt8?, b3: UInt8?, b4: UInt8?)
+    -> String?
 {
     let q = quintets(b0, b1, b2, b3, b4)
     if let
@@ -97,7 +84,7 @@ private func charactersForBytes(b0: UInt8, b1: UInt8?, b2: UInt8?, b3: UInt8?, b
         c6 = characterOrPaddingForValue(q.6),
         c7 = characterOrPaddingForValue(q.7)
     {
-        return (c0, c1, c2, c3, c4, c5, c6, c7)
+        return String([c0, c1, c2, c3, c4, c5, c6, c7])
     } else {
         return nil
     }

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -69,15 +69,8 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
         // The final quantum of encoding input is exactly 24 bits; here, the
         // final unit of encoded output will be five characters followed by
         // three "=" padding characters.
-        let q = quintets(bytes[0], bytes[1], bytes[2])
-        if let
-            c0 = characterForValue(q.0),
-            c1 = characterForValue(q.1),
-            c2 = characterForValue(q.2),
-            c3 = characterForValue(q.3),
-            c4 = characterForValue(q.4)
-        {
-            return String([c0, c1, c2, c3, c4, pad, pad, pad])
+        if let c = charactersForBytes(bytes[0], bytes[1], bytes[2], nil, nil) {
+            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
         }
     case 4:
         // The final quantum of encoding input is exactly 32 bits; here, the
@@ -100,7 +93,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
 }
 
 
-private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8?)
+private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8?, b4: UInt8?)
     -> (Character, Character, Character, Character, Character, Character, Character, Character)?
 {
     let q = quintets(b0, b1, b2, b3, b4)
@@ -110,8 +103,8 @@ private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: 
         c2 = characterForValue(q.2),
         c3 = characterForValue(q.3),
         c4 = characterForValue(q.4),
-        c5 = characterForValue(q.5),
-        c6 = characterForValue(q.6),
+        c5 = characterOrPaddingForValue(q.5),
+        c6 = characterOrPaddingForValue(q.6),
         c7 = characterOrPaddingForValue(q.7)
     {
         return (c0, c1, c2, c3, c4, c5, c6, c7)

--- a/Base32/Base32.swift
+++ b/Base32/Base32.swift
@@ -56,14 +56,8 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
         // The final quantum of encoding input is exactly 16 bits; here, the
         // final unit of encoded output will be four characters followed by
         // four "=" padding characters.
-        let q = quintets(bytes[0], bytes[1])
-        if let
-            c0 = characterForValue(q.0),
-            c1 = characterForValue(q.1),
-            c2 = characterForValue(q.2),
-            c3 = characterForValue(q.3)
-        {
-            return String([c0, c1, c2, c3, pad, pad, pad, pad])
+        if let c = charactersForBytes(bytes[0], bytes[1], nil, nil, nil) {
+            return String([c.0, c.1, c.2, c.3, c.4, c.5, c.6, c.7])
         }
     case 3:
         // The final quantum of encoding input is exactly 24 bits; here, the
@@ -93,7 +87,7 @@ private func encodeQuantum(bytes: ArraySlice<UInt8>) -> String? {
 }
 
 
-private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8?, b4: UInt8?)
+private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8?, b3: UInt8?, b4: UInt8?)
     -> (Character, Character, Character, Character, Character, Character, Character, Character)?
 {
     let q = quintets(b0, b1, b2, b3, b4)
@@ -102,7 +96,7 @@ private func charactersForBytes(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8?, b4:
         c1 = characterForValue(q.1),
         c2 = characterForValue(q.2),
         c3 = characterForValue(q.3),
-        c4 = characterForValue(q.4),
+        c4 = characterOrPaddingForValue(q.4),
         c5 = characterOrPaddingForValue(q.5),
         c6 = characterOrPaddingForValue(q.6),
         c7 = characterOrPaddingForValue(q.7)

--- a/Base32/Quintets.swift
+++ b/Base32/Quintets.swift
@@ -6,21 +6,20 @@
 //  Copyright (c) 2015 Matt Rubin. All rights reserved.
 //
 
-func quintets(b0: UInt8, b1: UInt8?, b2: UInt8?, b3: UInt8?, b4: UInt8?)
+func quintetsFromBytes(b: (UInt8, UInt8?, UInt8?, UInt8?, UInt8?))
     -> (UInt8, UInt8, UInt8?, UInt8?, UInt8?, UInt8?, UInt8?, UInt8?)
 {
     return (
-        firstQuintet(b0),
-        secondQuintet(b0, b1 ?? 0),
-        b1.map(thirdQuintet),
-        b1.map(fourthQuintet)?(b2 ?? 0),
-        b2.map(fifthQuintet)?(b3 ?? 0),
-        b3.map(sixthQuintet),
-        b3.map(seventhQuintet)?(b4 ?? 0),
-        b4.map(eigthQuintet)
+        firstQuintet(b.0),
+        secondQuintet(b.0, b.1 ?? 0),
+        b.1.map(thirdQuintet),
+        b.1.map(fourthQuintet)?(b.2 ?? 0),
+        b.2.map(fifthQuintet)?(b.3 ?? 0),
+        b.3.map(sixthQuintet),
+        b.3.map(seventhQuintet)?(b.4 ?? 0),
+        b.4.map(eigthQuintet)
     )
 }
-
 
 
 private func firstQuintet(b0: UInt8) -> UInt8 {

--- a/Base32/Quintets.swift
+++ b/Base32/Quintets.swift
@@ -38,8 +38,8 @@ func quintets(b0: UInt8, b1: UInt8, b2: UInt8)
     )
 }
 
-func quintets(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8)
-    -> (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
+func quintets(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8? = nil)
+    -> (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8?)
 {
     return (
         firstQuintet(b0),
@@ -48,22 +48,8 @@ func quintets(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8)
         fourthQuintet(b1, b2),
         fifthQuintet(b2, b3),
         sixthQuintet(b3),
-        seventhQuintet(b3, 0)
-    )
-}
-
-func quintets(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8)
-    -> (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)
-{
-    return (
-        firstQuintet(b0),
-        secondQuintet(b0, b1),
-        thirdQuintet(b1),
-        fourthQuintet(b1, b2),
-        fifthQuintet(b2, b3),
-        sixthQuintet(b3),
-        seventhQuintet(b3, b4),
-        eigthQuintet(b4)
+        seventhQuintet(b3, b4 ?? 0),
+        b4.map(eigthQuintet)
     )
 }
 

--- a/Base32/Quintets.swift
+++ b/Base32/Quintets.swift
@@ -26,29 +26,17 @@ func quintets(b0: UInt8, b1: UInt8)
     )
 }
 
-func quintets(b0: UInt8, b1: UInt8, b2: UInt8)
-    -> (UInt8, UInt8, UInt8, UInt8, UInt8)
+func quintets(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8?, b4: UInt8?)
+    -> (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8?, UInt8?, UInt8?)
 {
     return (
         firstQuintet(b0),
         secondQuintet(b0, b1),
         thirdQuintet(b1),
         fourthQuintet(b1, b2),
-        fifthQuintet(b2, 0)
-    )
-}
-
-func quintets(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8?)
-    -> (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8?)
-{
-    return (
-        firstQuintet(b0),
-        secondQuintet(b0, b1),
-        thirdQuintet(b1),
-        fourthQuintet(b1, b2),
-        fifthQuintet(b2, b3),
-        sixthQuintet(b3),
-        seventhQuintet(b3, b4 ?? 0),
+        fifthQuintet(b2, b3 ?? 0),
+        b3.map(sixthQuintet),
+        b3.map(seventhQuintet)?(b4 ?? 0),
         b4.map(eigthQuintet)
     )
 }
@@ -82,7 +70,7 @@ private func sixthQuintet(b3: UInt8) -> UInt8 {
     return ((b3 & 0b01111100) >> 2)
 }
 
-private func seventhQuintet(b3: UInt8, b4: UInt8) -> UInt8 {
+private func seventhQuintet(b3: UInt8)(_ b4: UInt8) -> UInt8 {
     return ((b3 & 0b00000011) << 3)
         |  ((b4 & 0b11100000) >> 5)
 }

--- a/Base32/Quintets.swift
+++ b/Base32/Quintets.swift
@@ -38,7 +38,7 @@ func quintets(b0: UInt8, b1: UInt8, b2: UInt8)
     )
 }
 
-func quintets(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8? = nil)
+func quintets(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8, b4: UInt8?)
     -> (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8?)
 {
     return (

--- a/Base32/Quintets.swift
+++ b/Base32/Quintets.swift
@@ -15,26 +15,15 @@ func quintets(b0: UInt8)
     )
 }
 
-func quintets(b0: UInt8, b1: UInt8)
-    -> (UInt8, UInt8, UInt8, UInt8)
+func quintets(b0: UInt8, b1: UInt8, b2: UInt8?, b3: UInt8?, b4: UInt8?)
+    -> (UInt8, UInt8, UInt8, UInt8, UInt8?, UInt8?, UInt8?, UInt8?)
 {
     return (
         firstQuintet(b0),
         secondQuintet(b0, b1),
         thirdQuintet(b1),
-        fourthQuintet(b1, 0)
-    )
-}
-
-func quintets(b0: UInt8, b1: UInt8, b2: UInt8, b3: UInt8?, b4: UInt8?)
-    -> (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8?, UInt8?, UInt8?)
-{
-    return (
-        firstQuintet(b0),
-        secondQuintet(b0, b1),
-        thirdQuintet(b1),
-        fourthQuintet(b1, b2),
-        fifthQuintet(b2, b3 ?? 0),
+        fourthQuintet(b1, b2 ?? 0),
+        b2.map(fifthQuintet)?(b3 ?? 0),
         b3.map(sixthQuintet),
         b3.map(seventhQuintet)?(b4 ?? 0),
         b4.map(eigthQuintet)
@@ -61,7 +50,7 @@ private func fourthQuintet(b1: UInt8, b2: UInt8) -> UInt8 {
         |  ((b2 & 0b11110000) >> 4)
 }
 
-private func fifthQuintet(b2: UInt8, b3: UInt8) -> UInt8 {
+private func fifthQuintet(b2: UInt8)(_ b3: UInt8) -> UInt8 {
     return ((b2 & 0b00001111) << 1)
         |  ((b3 & 0b10000000) >> 7)
 }

--- a/Base32/Quintets.swift
+++ b/Base32/Quintets.swift
@@ -6,8 +6,11 @@
 //  Copyright (c) 2015 Matt Rubin. All rights reserved.
 //
 
-func quintetsFromBytes(b: (UInt8, UInt8?, UInt8?, UInt8?, UInt8?))
-    -> (UInt8, UInt8, UInt8?, UInt8?, UInt8?, UInt8?, UInt8?, UInt8?)
+typealias Byte = UInt8
+typealias Quintet = UInt8
+
+func quintetsFromBytes(b: (Byte, Byte?, Byte?, Byte?, Byte?))
+    -> (Quintet, Quintet, Quintet?, Quintet?, Quintet?, Quintet?, Quintet?, Quintet?)
 {
     return (
         firstQuintet(b.0),
@@ -22,38 +25,38 @@ func quintetsFromBytes(b: (UInt8, UInt8?, UInt8?, UInt8?, UInt8?))
 }
 
 
-private func firstQuintet(b0: UInt8) -> UInt8 {
+private func firstQuintet(b0: Byte) -> Quintet {
     return ((b0 & 0b11111000) >> 3)
 }
 
-private func secondQuintet(b0: UInt8, b1: UInt8) -> UInt8 {
+private func secondQuintet(b0: Byte, b1: Byte) -> Quintet {
     return ((b0 & 0b00000111) << 2)
         |  ((b1 & 0b11000000) >> 6)
 }
 
-private func thirdQuintet(b1: UInt8) -> UInt8 {
+private func thirdQuintet(b1: Byte) -> Quintet {
     return ((b1 & 0b00111110) >> 1)
 }
 
-private func fourthQuintet(b1: UInt8)(_ b2: UInt8) -> UInt8 {
+private func fourthQuintet(b1: Byte)(_ b2: Byte) -> Quintet {
     return ((b1 & 0b00000001) << 4)
         |  ((b2 & 0b11110000) >> 4)
 }
 
-private func fifthQuintet(b2: UInt8)(_ b3: UInt8) -> UInt8 {
+private func fifthQuintet(b2: Byte)(_ b3: Byte) -> Quintet {
     return ((b2 & 0b00001111) << 1)
         |  ((b3 & 0b10000000) >> 7)
 }
 
-private func sixthQuintet(b3: UInt8) -> UInt8 {
+private func sixthQuintet(b3: Byte) -> Quintet {
     return ((b3 & 0b01111100) >> 2)
 }
 
-private func seventhQuintet(b3: UInt8)(_ b4: UInt8) -> UInt8 {
+private func seventhQuintet(b3: Byte)(_ b4: Byte) -> Quintet {
     return ((b3 & 0b00000011) << 3)
         |  ((b4 & 0b11100000) >> 5)
 }
 
-private func eigthQuintet(b4: UInt8) -> UInt8 {
+private func eigthQuintet(b4: Byte) -> Quintet {
     return (b4 & 0b00011111)
 }

--- a/Base32/Quintets.swift
+++ b/Base32/Quintets.swift
@@ -6,23 +6,14 @@
 //  Copyright (c) 2015 Matt Rubin. All rights reserved.
 //
 
-func quintets(b0: UInt8)
-    -> (UInt8, UInt8)
+func quintets(b0: UInt8, b1: UInt8?, b2: UInt8?, b3: UInt8?, b4: UInt8?)
+    -> (UInt8, UInt8, UInt8?, UInt8?, UInt8?, UInt8?, UInt8?, UInt8?)
 {
     return (
         firstQuintet(b0),
-        secondQuintet(b0, 0)
-    )
-}
-
-func quintets(b0: UInt8, b1: UInt8, b2: UInt8?, b3: UInt8?, b4: UInt8?)
-    -> (UInt8, UInt8, UInt8, UInt8, UInt8?, UInt8?, UInt8?, UInt8?)
-{
-    return (
-        firstQuintet(b0),
-        secondQuintet(b0, b1),
-        thirdQuintet(b1),
-        fourthQuintet(b1, b2 ?? 0),
+        secondQuintet(b0, b1 ?? 0),
+        b1.map(thirdQuintet),
+        b1.map(fourthQuintet)?(b2 ?? 0),
         b2.map(fifthQuintet)?(b3 ?? 0),
         b3.map(sixthQuintet),
         b3.map(seventhQuintet)?(b4 ?? 0),
@@ -45,7 +36,7 @@ private func thirdQuintet(b1: UInt8) -> UInt8 {
     return ((b1 & 0b00111110) >> 1)
 }
 
-private func fourthQuintet(b1: UInt8, b2: UInt8) -> UInt8 {
+private func fourthQuintet(b1: UInt8)(_ b2: UInt8) -> UInt8 {
     return ((b1 & 0b00000001) << 4)
         |  ((b2 & 0b11110000) >> 4)
 }

--- a/Base32Tests/AlphabetTests.swift
+++ b/Base32Tests/AlphabetTests.swift
@@ -44,6 +44,13 @@ class AlphabetTests: XCTestCase {
         assertCharacter("5", forValue: 29)
         assertCharacter("6", forValue: 30)
         assertCharacter("7", forValue: 31)
+
+        let remainingValues = Range<UInt8>(start: 32, end: 255)
+        for value: UInt8 in remainingValues {
+            if let resultingCharacter = characterForValue(value) {
+                XCTFail("\(value) translated to \"\(resultingCharacter)\" (expected nil)")
+            }
+        }
     }
 
     private func assertCharacter(expectedCharacter: Character, forValue value: UInt8) {

--- a/Base32Tests/Base32Tests.swift
+++ b/Base32Tests/Base32Tests.swift
@@ -33,7 +33,7 @@ class Base32Tests: XCTestCase {
 
     private func assertASCIIString(source: String, encodesToString destination: String) {
         if let data = (source as NSString).dataUsingEncoding(NSASCIIStringEncoding) {
-            if let result = Base32.encode(ArraySlice(data.byteArray)) {
+            if let result = base32(data.byteArray) {
                 XCTAssertEqual(result, destination, "\"\(source)\" encoded to \"\(result)\" (Expected \"\(destination)\")")
             } else {
                 XCTFail("Could not encode \"\(source)\" (Expected \"\(destination)\")")


### PR DESCRIPTION
- Remove dependency on `Foundation`
- Add public `base32()` function
- Consolidate functions for the five quantum cases
- Use `Byte` and `Quintet` type aliases to avoid `UInt8` ambiguity
- Test all possible values in alphabet test
