### PR TITLE
Fix Codecov default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bases
 
-[![codecov](https://codecov.io/gh/mattrubin/Bases/branch/master/graph/badge.svg)](https://codecov.io/gh/mattrubin/Bases)
+[![codecov](https://codecov.io/gh/mattrubin/Bases/branch/develop/graph/badge.svg)](https://codecov.io/gh/mattrubin/Bases)
 
 Swift frameworks for Base16, Base32, and Base64 encoding/decoding
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,8 @@
 # Configuration for Codecov (https://codecov.io)
 
-coverage:
+codecov:
   branch: develop
+
+coverage:
   ignore:
     - "Tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 # Configuration for Codecov (https://codecov.io)
 
 coverage:
+  branch: develop
   ignore:
     - "Tests"


### PR DESCRIPTION
Configure Codecov to treat the `develop` branch as the default.