### PR TITLE
Test failure cases

### DIFF
--- a/Tests/Base16Tests/Base16Tests.swift
+++ b/Tests/Base16Tests/Base16Tests.swift
@@ -49,4 +49,9 @@ class Base16Tests: XCTestCase {
             XCTAssertEqual(decodedResult, decodedData, "Encoded string \"\(encodedString)\" decoded to data \"\(decodedResult)\" (expected \"\(decodedData)\")")
         }
     }
+
+    func testDecodeNonASCII() {
+        let decodedResult = Base16.decode("🐙")
+        XCTAssertNil(decodedResult, "Unexpected decoded string: \(decodedResult)")
+    }
 }

--- a/Tests/Base16Tests/Base16Tests.swift
+++ b/Tests/Base16Tests/Base16Tests.swift
@@ -54,4 +54,11 @@ class Base16Tests: XCTestCase {
         let decodedResult = Base16.decode("🐙")
         XCTAssertNil(decodedResult, "Unexpected decoded string: \(decodedResult)")
     }
+
+    func testDecodePartialBlock() {
+        let decodedPartial = Base16.decode("6")
+        XCTAssertNil(decodedPartial, "Unexpected decoded string: \(decodedPartial)")
+        let decodedFull = Base16.decode("66")
+        XCTAssertEqual(decodedFull, Data(bytes: [102]), "Unexpected decoded string: \(decodedFull)")
+    }
 }


### PR DESCRIPTION
Add tests which cover the Base16 decoding failure cases.