### PR TITLE
Swift 5 memory API

### DIFF
--- a/Sources/Base32/Base32.swift
+++ b/Sources/Base32/Base32.swift
@@ -82,7 +82,8 @@ public enum Base32 {
         let encodedByteCount = nonPaddingByteCount(encodedData: encodedData)
 
         let decodedByteCount = try byteCount(decoding: encodedByteCount)
-        let decodedBytes = UnsafeMutablePointer<Byte>.allocate(capacity: decodedByteCount)
+        let decodedBytes = UnsafeMutableRawBufferPointer.allocate(byteCount: decodedByteCount,
+                                                                  alignment: MemoryLayout<Byte>.alignment)
 
         try encodedData.withUnsafeBytes { rawBuffer in
             let encodedChars: UnsafePointer<EncodedChar> = rawBuffer.bindMemory(to: EncodedChar.self).baseAddress!
@@ -127,7 +128,7 @@ public enum Base32 {
         }
 
         // The Data instance takes ownership of the allocated bytes and will handle deallocation.
-        return Data(bytesNoCopy: decodedBytes, count: decodedByteCount, deallocator: .free)
+        return Data(bytesNoCopy: decodedBytes.baseAddress!, count: decodedByteCount, deallocator: .free)
     }
 
     private static func nonPaddingByteCount(encodedData: Data) -> Int {

--- a/Sources/Base32/Base32.swift
+++ b/Sources/Base32/Base32.swift
@@ -37,15 +37,14 @@ public enum Base32 {
         let encodedByteCount = byteCount(encoding: unencodedByteCount)
         let encodedBytes = UnsafeMutablePointer<EncodedChar>.allocate(capacity: encodedByteCount)
 
-        data.withUnsafeBytes { rawBuffer in
-            let unencodedBytes: UnsafePointer<Byte> = rawBuffer.bindMemory(to: Byte.self).baseAddress!
-
+        data.withUnsafeBytes { unencodedBytes in
             var encodedWriteOffset = 0
             for unencodedReadOffset in stride(from: 0, to: unencodedByteCount, by: unencodedBlockSize) {
-                let nextBlockBytes = unencodedBytes + unencodedReadOffset
                 let nextBlockSize = min(unencodedBlockSize, unencodedByteCount - unencodedReadOffset)
+                let nextBlockSlice = unencodedBytes[unencodedReadOffset ..< unencodedReadOffset + nextBlockSize]
+                let nextBlockBytes = UnsafeRawBufferPointer(rebasing: nextBlockSlice)
 
-                let nextChars = encodeBlock(bytes: nextBlockBytes, size: nextBlockSize)
+                let nextChars = encodeBlock(bytes: nextBlockBytes)
                 encodedBytes[encodedWriteOffset + 0] = nextChars.0
                 encodedBytes[encodedWriteOffset + 1] = nextChars.1
                 encodedBytes[encodedWriteOffset + 2] = nextChars.2

--- a/Sources/Base32/Base32.swift
+++ b/Sources/Base32/Base32.swift
@@ -37,7 +37,9 @@ public enum Base32 {
         let encodedByteCount = byteCount(encoding: unencodedByteCount)
         let encodedBytes = UnsafeMutablePointer<EncodedChar>.allocate(capacity: encodedByteCount)
 
-        data.withUnsafeBytes { (unencodedBytes: UnsafePointer<Byte>) in
+        data.withUnsafeBytes { rawBuffer in
+            let unencodedBytes: UnsafePointer<Byte> = rawBuffer.bindMemory(to: Byte.self).baseAddress!
+
             var encodedWriteOffset = 0
             for unencodedReadOffset in stride(from: 0, to: unencodedByteCount, by: unencodedBlockSize) {
                 let nextBlockBytes = unencodedBytes + unencodedReadOffset
@@ -83,7 +85,9 @@ public enum Base32 {
         let decodedByteCount = try byteCount(decoding: encodedByteCount)
         let decodedBytes = UnsafeMutablePointer<Byte>.allocate(capacity: decodedByteCount)
 
-        try encodedData.withUnsafeBytes { (encodedChars: UnsafePointer<EncodedChar>) in
+        try encodedData.withUnsafeBytes { rawBuffer in
+            let encodedChars: UnsafePointer<EncodedChar> = rawBuffer.bindMemory(to: EncodedChar.self).baseAddress!
+
             var decodedWriteOffset = 0
             for encodedReadOffset in stride(from: 0, to: encodedByteCount, by: encodedBlockSize) {
                 let chars = encodedChars + encodedReadOffset

--- a/Sources/Base32/BlockEncoding.swift
+++ b/Sources/Base32/BlockEncoding.swift
@@ -26,8 +26,8 @@
 internal typealias EncodedBlock = (EncodedChar, EncodedChar, EncodedChar, EncodedChar, EncodedChar,
     EncodedChar, EncodedChar, EncodedChar)
 
-internal func encodeBlock(bytes: UnsafePointer<Byte>, size: Int) -> EncodedBlock {
-    switch size {
+internal func encodeBlock(bytes: UnsafeRawBufferPointer) -> EncodedBlock {
+    switch bytes.count {
     case 1:
         return encodeBlock(bytes[0])
     case 2:
@@ -39,7 +39,7 @@ internal func encodeBlock(bytes: UnsafePointer<Byte>, size: Int) -> EncodedBlock
     case 5:
         return encodeBlock(bytes[0], bytes[1], bytes[2], bytes[3], bytes[4])
     default:
-        fatalError("Cannot encode \(size) bytes. Max block size is five.")
+        fatalError("Cannot encode \(bytes.count) bytes. Max block size is five.")
     }
 }
 


### PR DESCRIPTION
Migrate off of [the deprecated version of `withUnsafeBytes`](https://developer.apple.com/documentation/foundation/data/1780450-withunsafebytes) to [the new method](https://developer.apple.com/documentation/foundation/data/3139154-withunsafebytes), replacing typed unsafe pointers with `UnsafeRawBufferPointer` and `UnsafeMutableRawBufferPointer`.

https://forums.swift.org/t/withunsafebytes-data-api-confusion/22142/4