### PR TITLE
Swift 5 memory API for Base16

### DIFF
--- a/Sources/Base16/Base16.swift
+++ b/Sources/Base16/Base16.swift
@@ -37,7 +37,7 @@ public enum Base16 {
         let encodedByteCount = unencodedByteCount * encodedBlockSize
         let encodedBytes = UnsafeMutablePointer<EncodedChar>.allocate(capacity: encodedByteCount)
 
-        data.withUnsafeBytes { (unencodedBytes: UnsafePointer<Byte>) in
+        data.withUnsafeBytes { unencodedBytes in
             var encodedWriteOffset = 0
             for unencodedReadOffset in stride(from: 0, to: unencodedByteCount, by: unencodedBlockSize) {
                 let nextUnencodedByte = unencodedBytes[unencodedReadOffset]
@@ -72,7 +72,7 @@ public enum Base16 {
         let decodedByteCount = try byteCount(decoding: encodedByteCount)
         let decodedBytes = UnsafeMutablePointer<Byte>.allocate(capacity: decodedByteCount)
 
-        try encodedData.withUnsafeBytes { (encodedBytes: UnsafePointer<Byte>) in
+        try encodedData.withUnsafeBytes { encodedBytes in
             var decodedWriteOffset = 0
             for encodedReadOffset in stride(from: 0, to: encodedByteCount, by: encodedBlockSize) {
                 let bigChar = encodedBytes[encodedReadOffset]

--- a/Tests/Base16Tests/Base16Tests.swift
+++ b/Tests/Base16Tests/Base16Tests.swift
@@ -102,7 +102,7 @@ class Base16Tests: XCTestCase {
         do {
             // Test full encoded block
             let decodedFull = try Base16.decode("66")
-            XCTAssertEqual(decodedFull, Data(bytes: [102]), "Unexpected decoded string: \(decodedFull)")
+            XCTAssertEqual(decodedFull, Data([102]), "Unexpected decoded string: \(decodedFull)")
         } catch {
             XCTFail("Unexpected error: \(error)")
         }


### PR DESCRIPTION
Migrate Base16 off of deprecated `Data` methods.