### PR TITLE
Fix Codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,11 +12,13 @@ coverage:
     project:
       default: false
       base16:
-        paths: "Sources/Base16/"
+        paths:
+          - "Sources/Base16/"
         # Allow coverage to drop by up to 1% without marking a PR with a failing status.
         threshold: 1
       base32:
-        paths: "Sources/Base32/"
+        paths:
+          - "Sources/Base32/"
         # Allow coverage to drop by up to 1% without marking a PR with a failing status.
         threshold: 1
     patch:


### PR DESCRIPTION
The previous YAML was failing validation, despite matching the documentation.