### PR TITLE
Replace the full license text in each source file with SPDX tags

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,6 @@ disabled_rules:
   - explicit_self
   - explicit_top_level_acl
   - explicit_type_interface
-  - file_header
   - file_name
   - file_types_order
   - force_unwrapping # FIXME
@@ -41,3 +40,8 @@ trailing_comma:
 line_length:
   ignores_function_declarations: true
   ignores_interpolated_strings: true
+
+file_header:
+  required_pattern: |
+    \/\/ SPDX-FileCopyrightText: © (\d{4}|\d{4}-\d{4}) Matt Rubin and the Bases authors
+    \/\/ SPDX-License-Identifier: MIT

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2019 Matt Rubin and the [Bases authors](AUTHORS.txt)
+Copyright © 2015-2026 Matt Rubin and the [Bases authors](AUTHORS.txt)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: © 2016-2026 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 // swift-tools-version: 6.0
 
 import PackageDescription

--- a/Sources/Base16/Alphabet.swift
+++ b/Sources/Base16/Alphabet.swift
@@ -1,27 +1,5 @@
-//
-//  Alphabet.swift
-//  Bases
-//
-//  Copyright (c) 2016-2018 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2016-2018 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 internal typealias Byte = UInt8
 internal typealias EncodedChar = UInt8

--- a/Sources/Base16/Base16.swift
+++ b/Sources/Base16/Base16.swift
@@ -1,27 +1,5 @@
-//
-//  Base16.swift
-//  Bases
-//
-//  Copyright (c) 2016-2019 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2016-2022 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 import Foundation
 

--- a/Sources/Base32/Alphabet.swift
+++ b/Sources/Base32/Alphabet.swift
@@ -1,27 +1,5 @@
-//
-//  Alphabet.swift
-//  Bases
-//
-//  Copyright (c) 2015-2018 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2015-2018 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 internal typealias EncodedChar = UInt8
 

--- a/Sources/Base32/Base32.swift
+++ b/Sources/Base32/Base32.swift
@@ -1,27 +1,5 @@
-//
-//  Base32.swift
-//  Bases
-//
-//  Copyright (c) 2015-2019 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2015-2022 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 import Foundation
 

--- a/Sources/Base32/BlockDecoding.swift
+++ b/Sources/Base32/BlockDecoding.swift
@@ -1,27 +1,5 @@
-//
-//  BlockDecoding.swift
-//  Bases
-//
-//  Copyright (c) 2017-2018 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2017-2018 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 internal func decodeBlock(
     _ c0: EncodedChar,

--- a/Sources/Base32/BlockEncoding.swift
+++ b/Sources/Base32/BlockEncoding.swift
@@ -1,27 +1,5 @@
-//
-//  BlockEncoding.swift
-//  Bases
-//
-//  Copyright (c) 2016-2019 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2016-2019 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 internal typealias EncodedBlock = (
     EncodedChar, EncodedChar, EncodedChar, EncodedChar,

--- a/Sources/Base32/Quintets.swift
+++ b/Sources/Base32/Quintets.swift
@@ -1,27 +1,5 @@
-//
-//  Quintets.swift
-//  Bases
-//
-//  Copyright (c) 2015-2018 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2015-2018 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 typealias Byte = UInt8
 typealias Quintet = UInt8

--- a/Sources/PerformanceTests/main.swift
+++ b/Sources/PerformanceTests/main.swift
@@ -1,27 +1,5 @@
-//
-//  main.swift
-//  PerformanceTests
-//
-//  Copyright (c) 2016 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2016-2026 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 import Base32
 import CoreFoundation

--- a/Tests/Base16Tests/Base16Tests.swift
+++ b/Tests/Base16Tests/Base16Tests.swift
@@ -1,27 +1,5 @@
-//
-//  Base16Tests.swift
-//  Base16Tests
-//
-//  Copyright (c) 2016-2019 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2016-2026 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 import Base16
 import Foundation

--- a/Tests/Base32Tests/Base32Tests.swift
+++ b/Tests/Base32Tests/Base32Tests.swift
@@ -1,27 +1,5 @@
-//
-//  Base32Tests.swift
-//  Base32Tests
-//
-//  Copyright (c) 2015-2018 Matt Rubin and the Bases authors
-//
-//  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
-//  furnished to do so, subject to the following conditions:
-//
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
-//
-//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
-//
+// SPDX-FileCopyrightText: © 2015-2026 Matt Rubin and the Bases authors
+// SPDX-License-Identifier: MIT
 
 import Base32
 import Foundation


### PR DESCRIPTION
Also, configure SwiftLint to validate these file header comments